### PR TITLE
Issue #8 - Add millisecond precision for mysql-compatible databases.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 Sparta Systems, Inc
+ * Copyright 2016 - 2017 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,9 @@ dependencies {
     testCompile(group: 'org.dbunit', name: 'dbunit', version: '2.5.1') {
         exclude(module: 'junit')
     }
+
+    // Our license makes distribution of mysql-connector-java undesirable, uncomment here for local mysql testing
+    // runtime group: 'mysql', name: 'mysql-connector-java', version: '6.0.5'
 }
 
 springBoot {

--- a/src/main/resources/db/migration/V1.1_001__message_received_precision.sql
+++ b/src/main/resources/db/migration/V1.1_001__message_received_precision.sql
@@ -1,0 +1,4 @@
+
+-- github issue 8 / add millisecond resolution
+alter table message modify received_date timestamp(3) not null;
+


### PR DESCRIPTION
Pretty hard to add test coverage for this one - our integration tests run against H2 whose timestamps are already millisecond-friendly.   

I had tried pulling in a project called mariaDB4j to run the integration tests against an embedded mariadb instance, but ran into a problem where milliseconds still didn't work because whatever transitive version of the connector that project was pulling in wouldn't work without 'useServerPrepStmts=true' on the JDBC url, and I didn't want that complexity coming in. 

