### PR TITLE
Fixes #16 Creating contribution guide

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for interest in Holdmail. What kind of issue would like you to raise?
+
+Question
+
+Feel free to ask us a question, don't be shy!  Include as much information below as possible
+
+Bug report / Enhancement
+
+Please follow template provided below closely.
+
+YOU CAN DELETE THIS TEXT BEFORE SUBMITTING THE ISSUE
+-->
+
+##### Question/Issue Overview
+
+Tell us briefly what this ticket is about.
+
+##### Expected Behavior
+
+What you think the system should be doing
+
+##### Current Behavior
+
+What its actually doing, and why this doesn't match your expectations
+
+##### Reproducible Sequence
+1. [step 1]
+2. [step 2]
+
+##### Additional Information
+
+Anything relevant to help us resolving the problem. For example if you are sending email, include any response codes in Holdmail, any log messages you receive, or screenshots of rendering issues.
+
+For long outputs such as stacktraces please use HTML5 `<details>`
+
+```
+<details>
+ <summary>Summary information</summary>
+ Long details go here
+</details>
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- 
+Many thanks for contributing to Holdmail! Soon, you'll be able to email all the things.
+
+Please tell us what this PR brings following the template we provided. 
+And don't forget to link to the issue (or create one if there is none).
+
+If you are still working on the change please prefix this pull request title with "WIP"
+
+YOU CAN DELETE THIS COMMENT WHEN YOU ARE DONE
+-->
+
+#### Short description of what this resolves:
+
+
+#### Changes proposed in this pull request:
+
+-
+-
+-
+
+
+**Fixes**: #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make [by creating an issue](https://github.com/SpartaSystems/holdmail/issues/new)
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Contribution Process
+
+We welcome all contributions to our code base from outisde parties.  We do require a few things with your contribution.
+
+1. All Contributions are made under the Apache License, v2.
+2. Our headers must be applied to all source files added to the codebase
+```
+ Copyright $year Sparta Systems, Inc
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied.
+ 
+ See the License for the specific language governing permissions and
+ limitations under the License.
+```
+3. Contributors waive copyright claims to their contributions.
+
+## Pull Request Process
+
+1. Ensure that all changes have proper test coverage.
+2. Ensure that new dependencies match our licensing requirements.
+   - New dependencies must be complementary to the Apache License, v2.
+3. Update the README.md with details of changes to the interface, this includes new environment 
+   variables, exposed ports, useful file locations and container parameters.
+4. Be open to discussing your changes.  Make sure the maintainers understand your reasoning
+   and respond appropriately to comments made.
+5. A maintainer will merge your pull request once all tests pass in Travis,
+   the quality is confirmed, and we there are no unresolved issues.  Feel free
+   to ping if you've not heard from us recently.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at *[INSERT EMAIL ADDRESS]*. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,8 @@ rat {
             'node_modules/**',
             '.idea/**',
             'README.md',
+            'CONTRIBUTING.md',
+            '.github/*',
             'docker/',
             'src/main/resources/static/js/bundle/holdmail.js',
             'src/main/resources/db/migration/*.sql',


### PR DESCRIPTION
Adding a contribution guide to give guidance on how to add features and functions to Holdmail.
Adding issue template and pull request template to simplify end user experience.