### PR TITLE
#49 - Force nightwatch to be at least 0.9.19 so that it doesn't fetch…

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2770,12 +2770,6 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "ejs": {
-      "version": "0.8.3",
-      "resolved": "http://artifactory.spartasystems.com:8081/artifactory/api/npm/javascript/ejs/-/ejs-0.8.3.tgz",
-      "integrity": "sha1-24qsR/+Ap9+CtMgsEm/olwhwYm8=",
-      "dev": true
-    },
     "electron-to-chromium": {
       "version": "1.3.27",
       "resolved": "http://artifactory.spartasystems.com:8081/artifactory/api/npm/javascript/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
@@ -7383,13 +7377,13 @@
       "dev": true
     },
     "nightwatch": {
-      "version": "0.9.16",
-      "resolved": "http://artifactory.spartasystems.com:8081/artifactory/api/npm/javascript/nightwatch/-/nightwatch-0.9.16.tgz",
-      "integrity": "sha1-xKw+xxGw/wR8PcqcZVc2XuI2UZ8=",
+      "version": "0.9.19",
+      "resolved": "http://10.0.8.150:8081/artifactory/api/npm/javascript/nightwatch/-/nightwatch-0.9.19.tgz",
+      "integrity": "sha1-S9l1cnPTC4RfBIR6mLcb6bt8Szs=",
       "dev": true,
       "requires": {
         "chai-nightwatch": "0.1.1",
-        "ejs": "0.8.3",
+        "ejs": "2.5.7",
         "lodash.clone": "3.0.3",
         "lodash.defaultsdeep": "4.3.2",
         "minimatch": "3.0.3",
@@ -7400,9 +7394,15 @@
         "q": "1.4.1"
       },
       "dependencies": {
+        "ejs": {
+          "version": "2.5.7",
+          "resolved": "http://10.0.8.150:8081/artifactory/api/npm/javascript/ejs/-/ejs-2.5.7.tgz",
+          "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+          "dev": true
+        },
         "minimatch": {
           "version": "3.0.3",
-          "resolved": "http://artifactory.spartasystems.com:8081/artifactory/api/npm/javascript/minimatch/-/minimatch-3.0.3.tgz",
+          "resolved": "http://10.0.8.150:8081/artifactory/api/npm/javascript/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
@@ -7411,7 +7411,7 @@
         },
         "q": {
           "version": "1.4.1",
-          "resolved": "http://artifactory.spartasystems.com:8081/artifactory/api/npm/javascript/q/-/q-1.4.1.tgz",
+          "resolved": "http://10.0.8.150:8081/artifactory/api/npm/javascript/q/-/q-1.4.1.tgz",
           "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
           "dev": true
         }

--- a/client/package.json
+++ b/client/package.json
@@ -72,7 +72,7 @@
     "less": "^2.7.3",
     "less-loader": "^4.0.5",
     "mocha": "^3.2.0",
-    "nightwatch": "^0.9.12",
+    "nightwatch": "^0.9.19",
     "opn": "^5.1.0",
     "optimize-css-assets-webpack-plugin": "^3.2.0",
     "ora": "^1.2.0",

--- a/client/test/unit/specs/components/MessageDetail.spec.js
+++ b/client/test/unit/specs/components/MessageDetail.spec.js
@@ -159,8 +159,6 @@ describe('MessageDetail.vue', () => {
             var alert = comp.$el.querySelector('#forward-alert')
 
             expect(alert.textContent.trim()).to.equal('Mail 63 successfully sent to test@test.com')
-
-            stub.restore()
             done()
           }, 0)
         })
@@ -175,13 +173,13 @@ describe('MessageDetail.vue', () => {
           comp.$nextTick(() => {
             triggerEvent(comp, '#fwdButton', 'click')
 
-            comp.$nextTick(() => {
+            setTimeout(function () {
               var alert = comp.$el.querySelector('#forward-error')
 
               expect(alert.textContent.trim()).to.equal('The forwardEmail field must be a valid email.')
 
               done()
-            })
+            }, 0)
           })
         })
       })


### PR DESCRIPTION
#### Short description of what this resolves:
Updates nightwatch so that it doesn't bring in an older version of ejs npm module.

#### Changes proposed in this pull request:
Force nightwatch to be at least 0.9.19.


**Fixes**: #49 
