### PR TITLE
[54] Added DELETE /rest/messages/{messageId} API to delete one message given its message id

### DIFF
--- a/src/main/java/com/spartasystems/holdmail/rest/MessageController.java
+++ b/src/main/java/com/spartasystems/holdmail/rest/MessageController.java
@@ -65,6 +65,12 @@ public class MessageController {
         return messageService.findMessages(recipientEmail, pageRequest);
     }
 
+    @RequestMapping(value = "/{messageId}", method = RequestMethod.DELETE)
+    public ResponseEntity deleteMessageContent(@PathVariable("messageId") long messageId) {
+        messageService.deleteMessage(messageId);
+        return ResponseEntity.ok().build();
+    }
+
     @RequestMapping(value = "/{messageId}")
     public ResponseEntity getMessageContent(@PathVariable("messageId") long messageId) {
 

--- a/src/main/java/com/spartasystems/holdmail/service/MessageService.java
+++ b/src/main/java/com/spartasystems/holdmail/service/MessageService.java
@@ -59,6 +59,10 @@ public class MessageService {
         return messageMapper.toDomain(entity);
     }
 
+    public void deleteMessage(Long id) {
+        messageRepository.delete(id);
+    }
+
     public Message getMessage(long messageId) {
 
         MessageEntity entity = messageRepository.findOne(messageId);

--- a/src/test/java/com/spartasystems/holdmail/integration/MessageControllerIntegrationTest.java
+++ b/src/test/java/com/spartasystems/holdmail/integration/MessageControllerIntegrationTest.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
-import static io.restassured.module.mockmvc.RestAssuredMockMvc.get;
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.*;
 import static java.lang.System.currentTimeMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.*;
@@ -204,6 +204,21 @@ public class MessageControllerIntegrationTest extends BaseIntegrationTest {
 
     }
 
+    @Test
+    public void shouldBeAbleToDeleteAnEmail() throws Exception {
+
+        String recipient = generateRecipient("msg-summary");
+
+        final String queryURIForRecipient = ENDPOINT_MESSAGES + "?recipient=" + recipient;
+
+        get(queryURIForRecipient).then().assertThat().body("messages.size()", equalTo(0));
+
+        smtpClient.sendTextEmail(FROM_EMAIL, recipient, "mail one", TEXT_BODY);
+
+        final int messageId = verifySingleHitAndGetMessageId(recipient);
+
+        delete(ENDPOINT_MESSAGES + "/" + messageId).then().assertThat().statusCode(200);
+    }
     // TODO: integration coverage for
     // TODO: message ContentId fetch
     // TODO: attachment content fetch


### PR DESCRIPTION
#### Short description of what this resolves:
This is an attempt to implement issue #54 

#### Changes proposed in this pull request:

Implemented `MessageController#deleteMessageContent(long)` and `MessageService#deleteMessage(Long)`.

