### PR TITLE
Issue #28 - Support RFC2231-encoded header value parameters, if present.

### DIFF
--- a/src/main/java/com/spartasystems/holdmail/domain/HeaderValueParam.java
+++ b/src/main/java/com/spartasystems/holdmail/domain/HeaderValueParam.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright 2017 Sparta Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.spartasystems.holdmail.domain;
+
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.spartasystems.holdmail.mime.MimeUtils.trimQuotes;
+
+/**
+ * Represents the key=value pair tokens in a {@link HeaderValue} object.
+ */
+final class HeaderValueParam {
+
+    /*
+        valid RFC2231 name patterns:
+            blah* - not split, but encoded
+            blah*123 = split, position=123, not encoded
+            blah*123* = split, position=123, encoded
+    */
+    private static final Pattern RFC2231_NAME_PATT = Pattern.compile("^(?<name>[^*]+)\\*((?<position>\\d+)\\*?)?$");
+    /*
+        valid RFC2231 value patterns:
+            blah
+            'encoding'en'blah
+            'encoding''blah
+            ''en'blah
+            ''blah
+     */
+    private static final Pattern RFC2231_VALUE_PATTERN = Pattern.compile("^((?<charset>.*?)?'(?<language>.*?)?')?(?<value>.*)$");
+
+    private final String name;
+    private final String value;
+    private final int position;
+    private final String charset;
+    private final String language;
+
+    /**
+     * @param nameValueString The input string of the form key=value
+     * @return The parsed {@link HeaderValueParam}, with RFC2231-aware fields parsed out, if present.
+     */
+    public static HeaderValueParam parse(String nameValueString) {
+
+        String[] nameValuePair = nameValueString.split("=");
+        String rawName = trimQuotes(nameValuePair[0]);
+        String rawValue = nameValuePair.length < 2 ? "" : trimQuotes(nameValuePair[1]);
+
+        Matcher nameMatcher = RFC2231_NAME_PATT.matcher(rawName);
+        if (!nameMatcher.matches()) {
+            return new HeaderValueParam(rawName, rawValue, 0, null, null);
+        }
+
+        int position = 0;
+        if (nameMatcher.group("position") != null) {
+            position = Integer.parseInt(nameMatcher.group("position"));
+        }
+
+        String name = nameMatcher.group("name");
+        String value = rawValue;
+        String charset = null;
+        String lang = null;
+
+        // the presence of a trailing '*' indicates whether to attempt to parse lang/charset info
+        if (rawName.endsWith("*")) {
+
+            Matcher valueMatcher = RFC2231_VALUE_PATTERN.matcher(value);
+            if (valueMatcher.matches()) {
+                value = valueMatcher.group("value");
+                charset = valueMatcher.group("charset");
+                lang = valueMatcher.group("language");
+            }
+
+        }
+
+        return new HeaderValueParam(name, value, position, charset, lang);
+    }
+
+    HeaderValueParam(String name, String value, int position, String charset, String language) {
+        this.name = name;
+        this.value = value;
+        this.position = position;
+        this.charset = charset;
+        this.language = language;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public String getCharset() {
+        return charset;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HeaderValueParam that = (HeaderValueParam) o;
+        return position == that.position &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(value, that.value) &&
+                Objects.equals(charset, that.charset) &&
+                Objects.equals(language, that.language);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(name, value, position, charset, language);
+    }
+
+    @Override
+    public String toString() {
+        return "HeaderValueParam{" +
+                "name='" + name + '\'' +
+                ", value='" + value + '\'' +
+                ", position=" + position +
+                ", charset='" + charset + '\'' +
+                ", language='" + language + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/spartasystems/holdmail/mime/MimeUtils.java
+++ b/src/main/java/com/spartasystems/holdmail/mime/MimeUtils.java
@@ -20,18 +20,33 @@ package com.spartasystems.holdmail.mime;
 
 import com.spartasystems.holdmail.domain.MessageContent;
 import com.spartasystems.holdmail.exception.HoldMailException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.parser.MimeStreamParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MimeUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(MimeUtils.class);
 
     private MimeUtils() {
     }
 
-    public static MessageContent parseMessageContent(InputStream in) {
+    /**
+     * Parse the provided inputstream into the message domain
+     * @param rawContentStream The inputstream to the message RAW content
+     * @return A {@link MessageContent} object representing the parsed content, or
+     *          a {@link HoldMailException} if parsing failed.
+     */
+    public static MessageContent parseMessageContent(final InputStream rawContentStream) {
 
         try {
             MessageContentExtractor bodyPartExtractor = new MessageContentExtractor();
@@ -39,12 +54,67 @@ public class MimeUtils {
             MimeStreamParser parser = new MimeStreamParser();
             parser.setContentDecoding(true);
             parser.setContentHandler(bodyPartExtractor);
-            parser.parse(in);
+            parser.parse(rawContentStream);
             return bodyPartExtractor.getParts();
         } catch (MimeException | IOException e) {
             throw new HoldMailException("Failed to parse body", e);
         }
 
+    }
+
+    /**
+     * Perform a {@link URLDecoder#decode(String, String)} but provide some null safety
+     * @param value The value to decode
+     * @param encoding The enconding
+     * @return The decoded string, or the original string if either the value or encoding were invalid.
+     */
+    public static String safeURLDecode(final String value, final String encoding) {
+
+        if(StringUtils.isBlank(value)){
+            logger.warn("No value was provided for decoding");
+            return value;
+        }
+
+        if(StringUtils.isBlank(encoding)){
+            logger.warn("No encoding name was provided for decoding, returning original value");
+            return value;
+        }
+
+        try {
+            return URLDecoder.decode(value, encoding);
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Couldn't decode value with encoding '" + encoding
+                    + "': " + e.getMessage() + ", value was:" + value);
+            return value;
+        }
+    }
+
+    /**
+     * Strip any leading/trailing spaces from the string.  Spaces inside the quotes will be maintained.
+     * <ul>
+     *     <li>null --&gt; null</li>
+     *     <li>"" --&gt; ""</li>
+     *     <li>"  blah  " -&gt; "blah"</li>
+     *     <li>" \"blah\" " -&gt; "blah"</li>
+     *     <li>" \" blah \" " -&gt; " blah "</li>
+     * </ul>
+     * @param input the input string
+     * @return The trimmed string
+     */
+    public static String trimQuotes(final String input) {
+
+        if(StringUtils.isBlank(input)){
+            return input;
+        }
+
+        final Pattern TRIM_PARAM_REGEX = Pattern.compile("^\\s*\"?(?<value>.*?)\"?\\s*$");
+
+        Matcher matcher = TRIM_PARAM_REGEX.matcher(input);
+        if (matcher.matches()) {
+            return matcher.group("value");
+        } else {
+            return input;
+        }
     }
 
 }

--- a/src/main/java/com/spartasystems/holdmail/smtp/OutgoingMailSender.java
+++ b/src/main/java/com/spartasystems/holdmail/smtp/OutgoingMailSender.java
@@ -46,7 +46,7 @@ public class OutgoingMailSender {
     @Value("${holdmail.outgoing.smtp.port:25000}")
     private int outgoingPort;
 
-    @Value("${holdmail.outgoing.mail.from:holdmail@localhost.localdomain}")
+    @Value("${holdmail.outgoing.mail.parse:holdmail@localhost.localdomain}")
     private String senderFrom;
 
     public String getOutgoingServer() {

--- a/src/main/java/com/spartasystems/holdmail/smtp/SMTPHandler.java
+++ b/src/main/java/com/spartasystems/holdmail/smtp/SMTPHandler.java
@@ -23,6 +23,8 @@ import com.spartasystems.holdmail.domain.MessageHeaders;
 import com.spartasystems.holdmail.service.MessageService;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.james.mime4j.Charsets;
+import org.apache.james.mime4j.codec.DecoderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,12 +91,12 @@ public class SMTPHandler implements MessageHandler {
             Session s = Session.getDefaultInstance(new Properties());
             MimeMessage mimeMsg = new MimeMessage(s, new ByteArrayInputStream(data));
 
-            // set any data from the mimemessage itself
+            // set any data parse the mimemessage itself
             MessageHeaders headers = getHeaders(mimeMsg);
 
             Message message = new Message(0,
                     mimeMsg.getMessageID(),
-                    headers.get("Subject"),
+                    DecoderUtil.decodeEncodedWords(headers.get("Subject"), Charsets.UTF_8),
                     this.senderEmail,
                     new Date(),
                     senderHost,
@@ -106,7 +108,7 @@ public class SMTPHandler implements MessageHandler {
 
             messageService.saveMessage(message);
 
-            logger.info(String.format("Stored SMTP message '%s' from %s to: %s",
+            logger.info(String.format("Stored SMTP message '%s' parse %s to: %s",
                     message.getIdentifier(),
                     message.getSenderEmail(),
                     StringUtils.join(message.getRecipients(), ","))

--- a/src/test/java/com/spartasystems/holdmail/domain/HeaderValueParamTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/HeaderValueParamTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright 2017 Sparta Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.spartasystems.holdmail.domain;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+import static com.spartasystems.holdmail.domain.HeaderValueParam.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HeaderValueParamTest {
+
+    @Test
+    public void shouldHandleNonRFC2231() {
+
+        assertThat(parse("")).isEqualTo(new HeaderValueParam("", "", 0, null, null));
+        assertThat(parse("nonkeyval")).isEqualTo(new HeaderValueParam("nonkeyval", "", 0, null, null));
+        assertThat(parse("key=val")).isEqualTo(new HeaderValueParam("key", "val", 0, null, null));
+    }
+
+    @Test
+    public void shouldHandleRFC2231Position() {
+
+        assertThat(parse("key*=val")).isEqualTo(new HeaderValueParam("key", "val", 0, null, null));
+        assertThat(parse("key*1=val")).isEqualTo(new HeaderValueParam("key", "val", 1, null, null));
+        assertThat(parse("key*5*=val")).isEqualTo(new HeaderValueParam("key", "val", 5, null, null));
+    }
+
+    @Test
+    public void shouldHandleRFC2231CharsetLang() {
+
+        assertThat(parse("key*=''val")).isEqualTo(new HeaderValueParam("key", "val", 0, "", ""));
+        assertThat(parse("key*=utf-8''val")).isEqualTo(new HeaderValueParam("key", "val", 0, "utf-8", ""));
+        assertThat(parse("key*='de'val")).isEqualTo(new HeaderValueParam("key", "val", 0, "", "de"));
+        assertThat(parse("key*=utf-8'de'val")).isEqualTo(new HeaderValueParam("key", "val", 0, "utf-8", "de"));
+
+        // same 4 tests again, only in combination with position
+        assertThat(parse("key*2*=''val")).isEqualTo(new HeaderValueParam("key", "val", 2, "", ""));
+        assertThat(parse("key*2*=utf-8''val")).isEqualTo(new HeaderValueParam("key", "val", 2, "utf-8", ""));
+        assertThat(parse("key*2*='de'val")).isEqualTo(new HeaderValueParam("key", "val", 2, "", "de"));
+        assertThat(parse("key*2*=utf-8'de'val")).isEqualTo(new HeaderValueParam("key", "val", 2, "utf-8", "de"));
+    }
+
+    @Test
+    public void shouldIgnoreRFC2231CharsetLangIfNotAsteriskSuffixed() {
+
+        assertThat(parse("key=utf-8'de'val")).isEqualTo(new HeaderValueParam("key", "utf-8'de'val", 0, null, null));
+        assertThat(parse("key*2=utf-8'de'val")).isEqualTo(new HeaderValueParam("key", "utf-8'de'val", 2, null, null));
+    }
+
+    @Test
+    public void shouldHaveValidEqualsHashcode() {
+
+        EqualsVerifier.forClass(HeaderValueParam.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+
+    }
+
+}

--- a/src/test/java/com/spartasystems/holdmail/domain/HeaderValueTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/HeaderValueTest.java
@@ -27,21 +27,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class HeaderValueTest {
 
-    public static final String SINGLE_PARAM       = "my-value; param1=thing.gif";
-    public static final String MULTI_PARAM        = "my-value; param1=\"0\"; param2=\"quoted\"; param3=unquoted";
-    public static final String MULTI_PARAM_SPACES = "my-value;   param1=\"0\"  ;   param2=\"quoted\"  ;  param3=unquoted  ";
-    public static final String NO_PARAMS          = "my-value";
+    private static final String SINGLE_PARAM = "my-value; param1=thing.gif";
+    private static final String MULTI_PARAM = "my-value; param1=\"0\"; param2=\"quoted\"; param3=unquoted";
+    private static final String MULTI_PARAM_SPACES = "my-value;   param1=\"0\"  ;   param2=\"quoted\"  ;  param3=unquoted  ";
+    private static final String NO_PARAMS = "my-value";
 
     @Test
-    public void shouldHaveValidEqualsHashCode() throws Exception {
+    public void shouldHaveValidEqualsHashCode() {
 
         EqualsVerifier.forClass(HeaderValue.class)
-                      .suppress(Warning.STRICT_INHERITANCE)
-                      .verify();
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
     }
 
     @Test
-    public void shouldHandleBlank() throws Exception {
+    public void shouldHandleBlank() {
 
         HeaderValue blank = new HeaderValue("");
         assertThat(blank.getValue()).isEqualTo("");
@@ -49,7 +49,7 @@ public class HeaderValueTest {
     }
 
     @Test
-    public void shouldMapNoParams() throws Exception {
+    public void shouldMapNoParams() {
 
         HeaderValue singleParam = new HeaderValue(NO_PARAMS);
         assertThat(singleParam.getValue()).isEqualTo("my-value");
@@ -58,7 +58,7 @@ public class HeaderValueTest {
     }
 
     @Test
-    public void shouldMapSingleParam() throws Exception {
+    public void shouldMapSingleParam() {
 
         HeaderValue singleParam = new HeaderValue(SINGLE_PARAM);
         assertThat(singleParam.getValue()).isEqualTo("my-value");
@@ -66,7 +66,7 @@ public class HeaderValueTest {
     }
 
     @Test
-    public void shouldMatchMultiParam() throws Exception {
+    public void shouldMatchMultiParam() {
 
         HeaderValue multiParam = new HeaderValue(MULTI_PARAM);
         assertThat(multiParam.getValue()).isEqualTo("my-value");
@@ -76,7 +76,7 @@ public class HeaderValueTest {
     }
 
     @Test
-    public void shouldMatchMultiParamWithSpacePadding() throws Exception {
+    public void shouldMatchMultiParamWithSpacePadding() {
 
         HeaderValue multiParam = new HeaderValue(MULTI_PARAM_SPACES);
         assertThat(multiParam.getValue()).isEqualTo("my-value");
@@ -86,7 +86,7 @@ public class HeaderValueTest {
     }
 
     @Test
-    public void shouldHaveValue() throws Exception{
+    public void shouldHaveValue() {
 
         HeaderValue headerValue = new HeaderValue(SINGLE_PARAM);
         assertThat(headerValue.hasValue("my-value")).isTrue();
@@ -95,7 +95,7 @@ public class HeaderValueTest {
     }
 
     @Test
-    public void shouldGetParamValue() throws Exception{
+    public void shouldGetParamValue() {
 
         HeaderValue multiParam = new HeaderValue(MULTI_PARAM_SPACES);
         assertThat(multiParam.getParamValue("param1")).isEqualTo("0");
@@ -106,5 +106,74 @@ public class HeaderValueTest {
 
 
     }
+
+    @Test
+    public void shouldDecodeRFC2231_MultiParam_NoEncoding() {
+
+        String in = "Content-Disposition: attachment;\n" +
+                " filename*2=[LAST];\n" +
+                " filename*0=[FIRST];\n" +
+                " filename*1=[MIDDLE]\n";
+
+        assertThat(new HeaderValue(in).getParamValue("filename"))
+                .isEqualTo("[FIRST][MIDDLE][LAST]");
+    }
+
+    @Test
+    public void shouldDecodeRFC2231_MultiParam_UTF8() {
+
+        String in = "Content-Disposition: attachment;\n" +
+                " filename*0*=utf-8''%E7%A7%81%E3%81%AE%E3%83%9B%E3%83%90%E3%83%BC%E3%82%AF;\n" +
+                " filename*1*=%E3%83%A9%E3%83%95%E3%83%88%E3%81%AF%E9%B0%BB%E3%81%A7%E3%81;\n" +
+                " filename*2*=%84%E3%81%A3%E3%81%B1%E3%81%84%E3%81%A7%E3%81%99\n";
+
+        assertThat(new HeaderValue(in).getParamValue("filename"))
+                .isEqualTo("私のホバークラフトは鰻でいっぱいです");
+    }
+
+    @Test
+    public void shouldDecodeRFC2231_MultiParam_NonUTF8() {
+
+        String in = "Content-Disposition: attachment;\n" +
+                " filename*0*=gb2312''%CE%D2%B5%C4%C6%F8%B5%E6%B4%AC%D7%B0%C2%FA%C1;" +
+                " filename*1*=%CB%F7%AD%D3%E3";
+
+        assertThat(new HeaderValue(in).getParamValue("filename"))
+                .isEqualTo("我的气垫船装满了鳝鱼");
+    }
+
+    @Test
+    public void shouldDecodeRFC2231_SingleParam() {
+
+        String in = "Content-Disposition: attachment;\n" +
+                " filename*=gb2312''%CE%D2%B5%C4%C6%F8%B5%E6%B4%AC%D7%B0%C2%FA%C1%CB%F7%AD%D3%E3";
+
+        assertThat(new HeaderValue(in).getParamValue("filename"))
+                .isEqualTo("我的气垫船装满了鳝鱼");
+    }
+
+    @Test
+    public void shouldDecodeRFC2231_SingleParam_IgnoreEncoding() {
+
+        // lack of a trailing asterisk means don't parse for encoding info
+        String in = "Content-Disposition: attachment;\n" +
+                " filename=gb2312''%CE%D2%B5%C4%C6%F8%B5%E6%B4%AC%D7%B0%C2%FA%C1%CB%F7%AD%D3%E3";
+
+        assertThat(new HeaderValue(in).getParamValue("filename"))
+                .isEqualTo("gb2312''%CE%D2%B5%C4%C6%F8%B5%E6%B4%AC%D7%B0%C2%FA%C1%CB%F7%AD%D3%E3");
+    }
+
+    @Test
+    public void shouldDecodeRFC2231_MultiParam_IgnoreEncoding() {
+
+        // lack of a trailing asterisk means don't parse for encoding info
+        String in = "Content-Disposition: attachment;\n" +
+                " filename*0=gb2312''%CE%D2%B5%C4%C6%F8%B5%E6%B4%AC%D7%B0%C2%FA%C1;" +
+                " filename*1=%CB%F7%AD%D3%E3";
+
+        assertThat(new HeaderValue(in).getParamValue("filename"))
+                .isEqualTo("gb2312''%CE%D2%B5%C4%C6%F8%B5%E6%B4%AC%D7%B0%C2%FA%C1%CB%F7%AD%D3%E3");
+    }
+
 
 }

--- a/src/test/java/com/spartasystems/holdmail/smtp/OutgoingMailSenderTest.java
+++ b/src/test/java/com/spartasystems/holdmail/smtp/OutgoingMailSenderTest.java
@@ -142,11 +142,11 @@ public class OutgoingMailSenderTest {
 
         Whitebox.setInternalState(mailSenderSpy, "outgoingServer", "outserver");
         Whitebox.setInternalState(mailSenderSpy, "outgoingPort", 999);
-        Whitebox.setInternalState(mailSenderSpy, "senderFrom", "from@host.tld");
+        Whitebox.setInternalState(mailSenderSpy, "senderFrom", "parse@host.tld");
 
         assertThat(mailSenderSpy.getOutgoingServer()).isEqualTo("outserver");
         assertThat(mailSenderSpy.getOutgoingPort()).isEqualTo(999);
-        assertThat(mailSenderSpy.getSenderFrom()).isEqualTo("from@host.tld");
+        assertThat(mailSenderSpy.getSenderFrom()).isEqualTo("parse@host.tld");
     }
 
 }


### PR DESCRIPTION
This PR adds a best-effort RFC2231 implementation, which hopefully should resolve a lot of the multilanguage problems holdmail has (attachment filenames, subject etc). 

This doesn't close out #28 - a future PR will add some improved integration coverage. 
