### PR TITLE
Enable a docker plugin for build time image creation (#27)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:8u92-alpine
+
+ARG JAR_FILE
+ARG CONF_FILE
+ARG PROP_FILE
+ARG MYSQL_CONNECTOR_VERSION=5.0.8
+
+RUN apk add --update bash curl unzip && \
+    rm -rf /var/cache/apk/*
+
+# Install MySQL Connector
+WORKDIR /opt/holdmail/lib
+RUN curl -sLO https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.zip && \
+    unzip mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.zip
+
+# Install Holdmail
+
+RUN mkdir -p /var/log/holdmail
+
+WORKDIR /etc
+ADD ${PROP_FILE} holdmail.properties
+
+WORKDIR /opt/holdmail/bin/
+ADD ${JAR_FILE} holdmail.jar
+ADD ${CONF_FILE} holdmail.conf
+
+EXPOSE 8080 25000
+
+ENTRYPOINT ["./holdmail.jar"]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ The UI can also be run in dev mode by navigating to the `client/` directory and 
   
   npm start
 
+## Run it from Docker
+
+Images of HoldMail are pushed to our [private docker registry](https://bintray.com/spartasystems/containers/sparta%3Aholdmail) hosted on Bintray.  The image pushed is our MySQL based image, and should be used within a docker compose or similar setup pointing to an external MySQL database.  You can find an example at [docker-compose.yml](https://github.com/SpartaSystems/holdmail/blob/master/docker/docker-compose.yml).
+
+If you want to pull the container yourself, you can use `docker pull spartasystems-docker-containers.bintray.io/sparta/holdmail`
+
+### Building the Docker container
+
+To build the application, including docker image and pushing to bintray, use the following gradle command:
+
+    ./gradlew build docker dockerPush
+    
+If you want to push to another registry, you can use `-DdockerName=your.repo/namespace/image-name` on the command line.
 	
 # Meta
 
@@ -148,7 +161,7 @@ HoldMail is licensed under the [Apache 2.0](LICENSE) license.
 
 ## Sparta Systems
 
-© Copyright 2016 Sparta Systems Inc. 
+© Copyright 2016 - 2018 Sparta Systems Inc. 
 
 [Sparta Systems](http://www.spartasystems.com) helps customers bring products to market safely and efficiently by delivering quality management software solutions that provide control and transparency throughout the enterprise and their critical supplier network. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 - 2017 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ plugins {
     id "com.github.jk1.dependency-license-report" version "0.4.1"
     id "net.researchgate.release" version "2.5.0"
     id "com.jfrog.bintray" version "1.7.3"
+    id "com.palantir.docker" version "0.17.2"
 }
 
 
@@ -36,6 +37,8 @@ description = 'holdmail'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
+
+def dockerName = System.getProperty("dockerName", "sparta/holdmail")
 
 dependencies {
 
@@ -106,6 +109,7 @@ rat {
             'README.md',
             'CONTRIBUTING.md',
             'RELEASE.md',
+            'Dockerfile',
             '.github/*',
             'docker/',
             'src/main/resources/db/migration/*.sql',
@@ -137,6 +141,12 @@ jar {
     }
 
     from { ['LICENSE', 'NOTICE', "$projectDir/build/thirdparty-licenses"] }
+}
+
+docker {
+    name dockerName
+    files jar.archivePath, './docker/assets/etc/holdmail.properties', './docker/assets/opt/holdmail/bin/holdmail.conf'
+    buildArgs(['JAR_FILE': "${jar.archiveName}", 'PROP_FILE': 'holdmail.properties', 'CONF_FILE':'holdmail.conf'])
 }
 
 def RPM_INSTALL_DIR = '/opt/holdmail'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ description = 'holdmail'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
-def dockerName = System.getProperty("dockerName", "sparta/holdmail")
+def dockerName = System.getProperty("dockerName", "spartasystems-docker-containers.bintray.io/sparta/holdmail")
 
 dependencies {
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016 Sparta Systems, Inc
+# Copyright 2016 - 2018 Sparta Systems, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,11 +27,13 @@ services:
       - MYSQL_USER=holdmail
       - MYSQL_PASSWORD=password
   holdmail:
-    build: .
+    image: spartasystems-docker-containers.bintray.io/sparta/holdmail
     container_name: holdmail
     hostname: holdmail
     ports:
       - "8080:8080"
       - "25000:25000"
+    volumes:
+      - "./assets/etc/holdmail.properties:/etc/holdmail.properties"
     links:
       - mysql

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016 Sparta Systems, Inc
+# Copyright 2016 - 2018 Sparta Systems, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,5 +17,4 @@
 ################################################################################
 
 
-version=1.0.5-SNAPSHOT
-
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
#### Short description of what this resolves:

Adds gradle commands to create a docker image during the build, based on build output instead.

#### Changes proposed in this pull request:

- Copy the existing `Dockerfile` into the root, removing the download part and replacing it with the locally built artifact.
- Leverage a gradle plugin to generate the docker image
- Allow the actual image to be configured via property, to allow users to push to private registries


**Fixes**: #27
