### PR TITLE
#63 - Return empty string if message detail not loaded yet

### DIFF
--- a/client/src/components/MessageDetail.vue
+++ b/client/src/components/MessageDetail.vue
@@ -137,7 +137,11 @@ export default {
       return receivedDate || 0
     },
     messageRawEndpoint () {
-      return messagesApi.getMessageRAWEndpoint(this.message.messageId)
+      if (this.message.messageId) {
+        return messagesApi.getMessageRAWEndpoint(this.message.messageId)
+      } else {
+        return ''
+      }
     }
   },
   methods: {

--- a/client/test/unit/specs/components/MessageDetail.spec.js
+++ b/client/test/unit/specs/components/MessageDetail.spec.js
@@ -194,6 +194,24 @@ describe('MessageDetail.vue', () => {
     })
   })
 
+  describe('Computed Properties', () => {
+    describe('messageRawEndpoint', () => {
+      it('returns empty string if message detail not fetched yet', () => {
+        comp = getMountedComponent()
+
+        expect(comp.messageRawEndpoint).to.equal('')
+      })
+
+      it('returns correct url path', () => {
+        stubMessageDetailSuccess(message1)
+
+        comp = getMountedComponent()
+
+        expect(comp.messageRawEndpoint).to.equal('/rest/messages/57/raw')
+      })
+    })
+  })
+
   const getComponent = () => {
     Vue.use(Router)
     var Constructor = Vue.extend(MessageDetail)


### PR DESCRIPTION
Fixes issue reported in #63 

#### Short description of what this resolves:
Does not attempt to generate URL if message ID is not known, returns empty string instead.

#### Changes proposed in this pull request:
- The fix
- Unit tests

**Fixes**: #63 
