### PR TITLE
Feature/14 remove 'messageRaw' attribute from summary model

### DIFF
--- a/src/main/java/com/spartasystems/holdmail/mapper/MessageSummaryMapper.java
+++ b/src/main/java/com/spartasystems/holdmail/mapper/MessageSummaryMapper.java
@@ -35,19 +35,11 @@ import static java.util.stream.Collectors.toList;
 @Component
 public class MessageSummaryMapper {
 
-    @Value("${holdmail.message.summary.enableraw:false}")
-    private boolean enableRaw;
-
     @Autowired
     private AttachmentMapper attachmentMapper;
 
     @Autowired
     private HTMLPreprocessor htmlPreprocessor;
-
-    // this support disappears in v2 (https://github.com/SpartaSystems/holdmail/issues/14)
-    boolean getEnableRaw() {
-        return enableRaw;
-    }
 
     public MessageSummary toMessageSummary(Message message) {
 
@@ -67,7 +59,6 @@ public class MessageSummaryMapper {
                 message.getSenderHost(),
                 message.getMessageSize(),
                 StringUtils.join(message.getRecipients(), ","),
-                getEnableRaw() ? message.getRawMessage() : null,
                 message.getHeaders().asMap(),
                 messageContent.findFirstTextPart(),
                 htmlPreprocessor.preprocess(message.getMessageId(), messageContent.findFirstHTMLPart()),

--- a/src/main/java/com/spartasystems/holdmail/mime/MessageContentExtractor.java
+++ b/src/main/java/com/spartasystems/holdmail/mime/MessageContentExtractor.java
@@ -39,13 +39,13 @@ class MessageContentExtractor extends AbstractContentHandler {
     }
 
     @Override
-    public void startHeader() throws MimeException {
+    public void startHeader() {
         nextPotentialPart = new MessageContentPart();
         nextPotentialPart.setSequence(bodyParts.size()+1);
     }
 
     @Override
-    public void field(Field field) throws MimeException {
+    public void field(Field field) {
 
         // field may have been called after a message container header()
         if(nextPotentialPart != null) {
@@ -55,7 +55,7 @@ class MessageContentExtractor extends AbstractContentHandler {
 
 
     @Override
-    public void body(BodyDescriptor bd, InputStream is) throws MimeException, IOException {
+    public void body(BodyDescriptor bd, InputStream is) throws IOException {
 
         nextPotentialPart.setContent(is);
         bodyParts.addPart(nextPotentialPart);

--- a/src/main/java/com/spartasystems/holdmail/model/MessageSummary.java
+++ b/src/main/java/com/spartasystems/holdmail/model/MessageSummary.java
@@ -38,14 +38,13 @@ public class MessageSummary {
     private final String                  senderHost;
     private final int                     messageSize;
     private final String                  recipients;
-    private final String                  messageRaw;
     private final Map<String, String>     messageHeaders;
     private final String                  messageBodyText;
     private final String                  messageBodyHTML;
     private final List<MessageAttachment> attachments;
 
     public MessageSummary(long messageId, String identifier, String subject, String senderEmail,
-            Date receivedDate, String senderHost, int messageSize, String recipients, String messageRaw,
+            Date receivedDate, String senderHost, int messageSize, String recipients,
             Map<String, String> messageHeaders, String messageBodyText, String messageBodyHTML,
             List<MessageAttachment> attachments) {
         this.messageId = messageId;
@@ -56,7 +55,6 @@ public class MessageSummary {
         this.senderHost = senderHost;
         this.messageSize = messageSize;
         this.recipients = recipients;
-        this.messageRaw = messageRaw;
         this.messageHeaders = messageHeaders;
         this.messageBodyText = messageBodyText;
         this.messageBodyHTML = messageBodyHTML;
@@ -93,10 +91,6 @@ public class MessageSummary {
 
     public String getRecipients() {
         return recipients;
-    }
-
-    public String getMessageRaw() {
-        return messageRaw;
     }
 
     public Map<String, String> getMessageHeaders() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,7 +46,4 @@ security.basic.enabled=false
 #security.user.name=user
 #security.user.password=pass
 
-# re-enable 'messageRaw' support in the /rest/messages/ID endpoint, but support will be dropped in 2.0
-# See https://github.com/SpartaSystems/holdmail/issues/14
-# holdmail.message.summary.enableraw=true
 

--- a/src/test/java/com/spartasystems/holdmail/EntityPersistenceTest.java
+++ b/src/test/java/com/spartasystems/holdmail/EntityPersistenceTest.java
@@ -50,7 +50,7 @@ public class EntityPersistenceTest extends BaseIntegrationTest {
     private MessageRepository messageRepository;
 
     @Test
-    public void shouldSaveEmail() throws Exception {
+    public void shouldSaveEmail() {
 
         MessageEntity entity = buildBasicEntity();
 
@@ -70,7 +70,7 @@ public class EntityPersistenceTest extends BaseIntegrationTest {
     }
 
     @Test
-    public void shouldSaveHeaders() throws Exception {
+    public void shouldSaveHeaders() {
 
         MessageEntity entity = buildBasicEntity();
 
@@ -93,7 +93,7 @@ public class EntityPersistenceTest extends BaseIntegrationTest {
     }
 
     @Test
-    public void shouldSaveRecipients() throws Exception {
+    public void shouldSaveRecipients() {
 
         MessageEntity entity = buildBasicEntity();
 
@@ -127,7 +127,7 @@ public class EntityPersistenceTest extends BaseIntegrationTest {
      */
     @Test
     @Transactional(Transactional.TxType.NEVER)
-    public void shouldSaveWithMillisPrecision_issue8() throws Exception{
+    public void shouldSaveWithMillisPrecision_issue8() {
 
         MessageEntity messageEntity = buildBasicEntity();
 

--- a/src/test/java/com/spartasystems/holdmail/HoldMailApplicationTest.java
+++ b/src/test/java/com/spartasystems/holdmail/HoldMailApplicationTest.java
@@ -31,7 +31,7 @@ import org.springframework.boot.SpringApplication;
 public class HoldMailApplicationTest {
 
     @Test
-    public void shouldInvokeSpringApp() throws Exception{
+    public void shouldInvokeSpringApp() {
 
         String[] args = {"a", "b", "c"};
 

--- a/src/test/java/com/spartasystems/holdmail/domain/MessageContentPartTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/MessageContentPartTest.java
@@ -44,7 +44,7 @@ public class MessageContentPartTest {
     public static final String NON_ASCII_STR = "Donaudampfschiffahrtselektrizitätenhauptbetriebswerkbauunterbeamtengesellschaft";
 
     @Test
-    public void shouldSetAndGetHeaders() throws Exception {
+    public void shouldSetAndGetHeaders() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         assertThat(messageContentPart.getHeaders()).isEmpty();
@@ -62,7 +62,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldGetContentType() throws Exception {
+    public void shouldGetContentType() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         assertThat(messageContentPart.getContentType()).isNull();
@@ -73,7 +73,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldGetIsHTML() throws Exception {
+    public void shouldGetIsHTML() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         assertThat(messageContentPart.isHTML()).isFalse();
@@ -86,7 +86,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldGetIsText() throws Exception {
+    public void shouldGetIsText() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         assertThat(messageContentPart.isText()).isFalse();
@@ -99,7 +99,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldHaveContentId() throws Exception {
+    public void shouldHaveContentId() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         assertThat(messageContentPart.hasContentId("thing")).isFalse();
@@ -164,7 +164,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnIsAttachmentTrueWhenDispositionIsInline() throws Exception {
+    public void shouldReturnIsAttachmentTrueWhenDispositionIsInline() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         messageContentPart.setHeader(CONTENT_DISPOSITION, "inline");
@@ -173,7 +173,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnIsAttachmentTrueWhenDispositionIsAttachment() throws Exception {
+    public void shouldReturnIsAttachmentTrueWhenDispositionIsAttachment() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         messageContentPart.setHeader(CONTENT_DISPOSITION, "attachment");
@@ -182,7 +182,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnIsAttachmentFalseWhenDispositionAnythingElse() throws Exception {
+    public void shouldReturnIsAttachmentFalseWhenDispositionAnythingElse() {
 
         // not set at all
         MessageContentPart messageContentPart = new MessageContentPart();
@@ -208,7 +208,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnNullAttachmentFilenameIfNotAttachment() throws Exception {
+    public void shouldReturnNullAttachmentFilenameIfNotAttachment() {
 
         MessageContentPart partSpy = spy(new MessageContentPart());
         doReturn(false).when(partSpy).isAttachment();
@@ -217,7 +217,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnAttachmentFilenameFromDisposition() throws Exception {
+    public void shouldReturnAttachmentFilenameFromDisposition() {
 
         MessageContentPart part = new MessageContentPart();
         part.setHeader(FieldName.CONTENT_DISPOSITION, "inline; filename=myfile.pdf");
@@ -228,7 +228,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnAttachmentFilenameFromContentTypeFallback() throws Exception {
+    public void shouldReturnAttachmentFilenameFromContentTypeFallback() {
 
         MessageContentPart part = new MessageContentPart();
         part.setHeader(FieldName.CONTENT_DISPOSITION, "inline; a=b;"); // no 'filename' param
@@ -239,7 +239,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnNullAttachmentFilenameFallback() throws Exception {
+    public void shouldReturnNullAttachmentFilenameFallback() {
 
         MessageContentPart part = new MessageContentPart();
         part.setHeader(FieldName.CONTENT_DISPOSITION, "inline; a=b;"); // no 'filename' param
@@ -266,7 +266,7 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageContentPart.class)
                       .suppress(Warning.NONFINAL_FIELDS,

--- a/src/test/java/com/spartasystems/holdmail/domain/MessageContentTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/MessageContentTest.java
@@ -51,7 +51,7 @@ public class MessageContentTest {
     private MessageContentPart part4Mock;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
 
         when(part1Mock.getContentString()).thenReturn(PART_1_CONTENT);
         when(part2Mock.getContentString()).thenReturn(PART_2_CONTENT);
@@ -61,7 +61,7 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldHaveNoPartsOnConstruction() throws Exception {
+    public void shouldHaveNoPartsOnConstruction() {
 
         MessageContent messageContent = new MessageContent();
 
@@ -70,7 +70,7 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldAddParts() throws Exception {
+    public void shouldAddParts() {
 
         MessageContent messageContent = new MessageContent();
         messageContent.addPart(part1Mock);
@@ -80,14 +80,14 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldNotFindFirstHTMLBody() throws Exception {
+    public void shouldNotFindFirstHTMLBody() {
 
         MessageContent messageContent = buildMimeBodyPartsWith4Parts();
         assertThat(messageContent.findFirstHTMLPart()).isNull();
     }
 
     @Test
-    public void shouldFindFirstHTMLBody() throws Exception {
+    public void shouldFindFirstHTMLBody() {
 
         when(part2Mock.isHTML()).thenReturn(true);
 
@@ -98,14 +98,14 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldNotFindFirstTextBody() throws Exception {
+    public void shouldNotFindFirstTextBody() {
 
         MessageContent messageContent = buildMimeBodyPartsWith4Parts();
         assertThat(messageContent.findFirstTextPart()).isNull();
     }
 
     @Test
-    public void shouldFindFirstTextBody() throws Exception {
+    public void shouldFindFirstTextBody() {
 
         when(part4Mock.isText()).thenReturn(true);
 
@@ -116,7 +116,7 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldFindAllAttachments() throws Exception {
+    public void shouldFindAllAttachments() {
 
         when(part1Mock.isAttachment()).thenReturn(false);
         when(part2Mock.isAttachment()).thenReturn(true);
@@ -130,14 +130,14 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldNotFindByContentId() throws Exception {
+    public void shouldNotFindByContentId() {
 
         MessageContent messageContent = buildMimeBodyPartsWith4Parts();
         assertThat(messageContent.findByContentId("blah")).isNull();
     }
 
     @Test
-    public void shouldFindByContentId() throws Exception {
+    public void shouldFindByContentId() {
 
         when(part3Mock.hasContentId("herp derp")).thenReturn(true);
 
@@ -148,14 +148,14 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldNotFindBySequenceId() throws Exception {
+    public void shouldNotFindBySequenceId() {
 
         MessageContent messageContent = buildMimeBodyPartsWith4Parts();
         assertThat(messageContent.findBySequenceId(555)).isNull();
     }
 
     @Test
-    public void shouldFindBySequenceId() throws Exception {
+    public void shouldFindBySequenceId() {
 
         when(part4Mock.getSequence()).thenReturn(54);
 
@@ -166,7 +166,7 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldHaveToString() throws Exception {
+    public void shouldHaveToString() {
 
         when(part1Mock.toString()).thenReturn("mbp1");
         when(part2Mock.toString()).thenReturn("mbp2");
@@ -180,7 +180,7 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldGetSize() throws Exception {
+    public void shouldGetSize() {
 
         MessageContent parts0 = new MessageContent();
         assertThat(parts0.size()).isEqualTo(0);
@@ -195,7 +195,7 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageContent.class)
                       .suppress(Warning.NONFINAL_FIELDS,

--- a/src/test/java/com/spartasystems/holdmail/domain/MessageHeadersTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/MessageHeadersTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MessageHeadersTest {
 
     @Test
-    public void shouldSetEmptyMapOnConstructor() throws Exception {
+    public void shouldSetEmptyMapOnConstructor() {
 
         MessageHeaders headers = new MessageHeaders();
         assertThat(headers.asMap()).isEmpty();
@@ -38,7 +38,7 @@ public class MessageHeadersTest {
     }
 
     @Test
-    public void shouldSetMapOnMapCopyContructor() throws Exception {
+    public void shouldSetMapOnMapCopyContructor() {
 
         Map<String, String> otherMap = of("k1", "v1", "k2", "v2");
 
@@ -48,7 +48,7 @@ public class MessageHeadersTest {
     }
 
     @Test
-    public void shouldAddValueOnPutOfNewKey() throws Exception {
+    public void shouldAddValueOnPutOfNewKey() {
 
         MessageHeaders headers = new MessageHeaders(of("name", "Mary"));
         headers.put("age", "10");
@@ -58,7 +58,7 @@ public class MessageHeadersTest {
     }
 
     @Test
-    public void shouldReplaceValueOnPutOfExistingKEy() throws Exception {
+    public void shouldReplaceValueOnPutOfExistingKEy() {
 
         MessageHeaders headers = new MessageHeaders(of("name", "Alex", "age", "15"));
 
@@ -69,7 +69,7 @@ public class MessageHeadersTest {
     }
 
     @Test
-    public void shouldGetValue() throws Exception {
+    public void shouldGetValue() {
 
         MessageHeaders headers = new MessageHeaders(of("name", "Alex", "age", "15"));
 
@@ -79,7 +79,7 @@ public class MessageHeadersTest {
     }
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageHeaders.class)
                       .suppress(Warning.NONFINAL_FIELDS,
@@ -90,7 +90,7 @@ public class MessageHeadersTest {
     }
 
     @Test
-    public void shouldHaveToString() throws Exception{
+    public void shouldHaveToString() {
 
         MessageHeaders headers = new MessageHeaders(of("name", "Alex", "age", "15"));
 

--- a/src/test/java/com/spartasystems/holdmail/domain/MessageTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/MessageTest.java
@@ -55,12 +55,12 @@ public class MessageTest {
     public static final  String RAW_CONTENT = "someRawContent";
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mockStatic(MimeUtils.class);
     }
 
     @Test
-    public void shouldSetIdentifierOnConstructor() throws Exception {
+    public void shouldSetIdentifierOnConstructor() {
 
         Message message = buildMessage("derpId", "");
         assertThat(message.getIdentifier()).isEqualTo("derpId");

--- a/src/test/java/com/spartasystems/holdmail/exception/HoldMailExceptionTest.java
+++ b/src/test/java/com/spartasystems/holdmail/exception/HoldMailExceptionTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HoldMailExceptionTest {
 
     @Test
-    public void shouldSetMessage() throws Exception{
+    public void shouldSetMessage() {
 
         final String MESSAGE = "the message";
         final Throwable CAUSE = new Throwable();

--- a/src/test/java/com/spartasystems/holdmail/integration/BuildInfoIntegrationTest.java
+++ b/src/test/java/com/spartasystems/holdmail/integration/BuildInfoIntegrationTest.java
@@ -41,7 +41,7 @@ public class BuildInfoIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    public void shouldConformToBuildInfoSchema() throws Exception {
+    public void shouldConformToBuildInfoSchema() {
 
         get("/rest/buildInfo").then()
                               .assertThat()

--- a/src/test/java/com/spartasystems/holdmail/mapper/AttachmentMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/AttachmentMapperTest.java
@@ -33,12 +33,12 @@ public class AttachmentMapperTest {
     private AttachmentMapper attachmentMapper;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         attachmentMapper = new AttachmentMapper();
     }
 
     @Test
-    public void shouldMapFromContentPart() throws Exception {
+    public void shouldMapFromContentPart() {
 
         MessageContentPart partSpy = spy(new MessageContentPart());
         partSpy.setHeader(FieldName.CONTENT_DISPOSITION, "my-disposition; a=b; c=d;");

--- a/src/test/java/com/spartasystems/holdmail/mapper/BuildInfoMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/BuildInfoMapperTest.java
@@ -44,7 +44,7 @@ public class BuildInfoMapperTest {
     private BuildInfoMapper buildInfoMapper;
 
     @Test
-    public void shouldMapFromProperties() throws Exception {
+    public void shouldMapFromProperties() {
 
         when(buildPropertiesMock.getVersion()).thenReturn(BUILD_VERSION);
         when(buildPropertiesMock.getTime()).thenReturn(BUILD_TIME);

--- a/src/test/java/com/spartasystems/holdmail/mapper/MessageListMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/MessageListMapperTest.java
@@ -55,7 +55,7 @@ public class MessageListMapperTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldMapEntityListToMessageList() throws Exception{
+    public void shouldMapEntityListToMessageList() {
 
         List<MessageEntity> entityListMock = mock(List.class);
         Stream<MessageEntity> streamMock = mock(Stream.class);
@@ -67,7 +67,7 @@ public class MessageListMapperTest {
         assertThat(messageListMapperSpy.toMessageList(entityListMock)).isEqualTo(messageListMock);
     }
 
-    public void shouldMapEntityStreamToMessageList() throws Exception {
+    public void shouldMapEntityStreamToMessageList() {
 
         MessageEntity entityMock1 = mock(MessageEntity.class);
         MessageEntity entityMock2 = mock(MessageEntity.class);
@@ -81,13 +81,13 @@ public class MessageListMapperTest {
     }
 
     @Test
-    public void shouldMapToEmptyListWhenStreamIsEmpty() throws Exception {
+    public void shouldMapToEmptyListWhenStreamIsEmpty() {
         MessageList messageList = messageListMapperSpy.toMessageList(Stream.empty());
         assertThat(messageList.getMessages()).isEmpty();
     }
 
     @Test
-    public void shouldMapToMessageListItem() throws Exception{
+    public void shouldMapToMessageListItem() {
 
         MessageRecipientEntity recipientEntity1 = new MessageRecipientEntity(EMAIL_HOMER);
         MessageRecipientEntity recipientEntity2 = new MessageRecipientEntity(EMAIL_MONTY);

--- a/src/test/java/com/spartasystems/holdmail/mapper/MessageMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/MessageMapperTest.java
@@ -55,7 +55,7 @@ public class MessageMapperTest {
     private static final MessageMapper  messageMapper = new MessageMapper();
 
     @Test
-    public void shouldMapFromDomain() throws Exception {
+    public void shouldMapFromDomain() {
 
         Message messageDomain = new Message(messageId, IDENTIFIER, subject, senderEmail, receivedDate,
                 senderHost, messageSize, rawMessage, recipients, headers);
@@ -81,7 +81,7 @@ public class MessageMapperTest {
     }
 
     @Test
-    public void shouldMapToDomain() throws Exception {
+    public void shouldMapToDomain() {
         MessageEntity messageEntity = getMessageEntity();
 
         Message message = messageMapper.toDomain(messageEntity);

--- a/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
@@ -78,7 +78,7 @@ public class MessageSummaryMapperTest {
     private MessageSummaryMapper messageSummaryMapperSpy;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
 
         doReturn(messageContentMock).when(MESSAGE_SPY).getContent();
 
@@ -89,7 +89,7 @@ public class MessageSummaryMapperTest {
     }
 
     @Test
-    public void shouldMapToMessageSummaryWithRAW() throws Exception {
+    public void shouldMapToMessageSummaryWithRAW() {
 
         MessageSummary expected = new MessageSummary(MESSAGE_ID, IDENTIFIER, SUBJECT, SENDER_MAIL,
                 RECEIVED, SENDER_HOST, MESSAGE_SIZE, "recip1,recip2",
@@ -102,7 +102,7 @@ public class MessageSummaryMapperTest {
     }
 
     @Test
-    public void shouldMapAttachments() throws Exception {
+    public void shouldMapAttachments() {
 
         MessageContentPart attContentMock1 = mock(MessageContentPart.class);
         MessageContentPart attContentMock2 = mock(MessageContentPart.class);

--- a/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
@@ -93,29 +93,11 @@ public class MessageSummaryMapperTest {
 
         MessageSummary expected = new MessageSummary(MESSAGE_ID, IDENTIFIER, SUBJECT, SENDER_MAIL,
                 RECEIVED, SENDER_HOST, MESSAGE_SIZE, "recip1,recip2",
-                RAW_CONTENT, HEADER_VALS, CONTENT_TXT, CONTENT_HTML_PROCESSED, Collections.emptyList());
-
-        doReturn(true).when(messageSummaryMapperSpy).getEnableRaw();
+                HEADER_VALS, CONTENT_TXT, CONTENT_HTML_PROCESSED, Collections.emptyList());
 
         MessageSummary actual = messageSummaryMapperSpy.toMessageSummary(MESSAGE_SPY);
 
         assertThat(actual).isEqualTo(expected);
-
-    }
-
-    @Test
-    public void shouldMapToMessageSummaryWithoutRAW() throws Exception {
-
-        MessageSummary expected = new MessageSummary(MESSAGE_ID, IDENTIFIER, SUBJECT, SENDER_MAIL,
-                RECEIVED, SENDER_HOST, MESSAGE_SIZE, "recip1,recip2",
-                null, HEADER_VALS, CONTENT_TXT, CONTENT_HTML_PROCESSED, Collections.emptyList());
-
-        doReturn(false).when(messageSummaryMapperSpy).getEnableRaw();
-
-        MessageSummary actual = messageSummaryMapperSpy.toMessageSummary(MESSAGE_SPY);
-
-        assertThat(actual).isEqualTo(expected);
-
 
     }
 

--- a/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
@@ -89,7 +89,7 @@ public class MessageSummaryMapperTest {
     }
 
     @Test
-    public void shouldMapToMessageSummaryWithRAW() {
+    public void shouldMapToMessageSummary() {
 
         MessageSummary expected = new MessageSummary(MESSAGE_ID, IDENTIFIER, SUBJECT, SENDER_MAIL,
                 RECEIVED, SENDER_HOST, MESSAGE_SIZE, "recip1,recip2",

--- a/src/test/java/com/spartasystems/holdmail/mime/MessageContentExtractorTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mime/MessageContentExtractorTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 public class MessageContentExtractorTest {
 
     @Test
-    public void shouldInitializeOnConstructor() throws Exception {
+    public void shouldInitializeOnConstructor() {
 
         MessageContentExtractor extractor = new MessageContentExtractor();
 
@@ -50,7 +50,7 @@ public class MessageContentExtractorTest {
     }
 
     @Test
-    public void shouldStartHeader() throws Exception{
+    public void shouldStartHeader() {
 
         MessageContentExtractor extractor = new MessageContentExtractor();
         assertThat(extractor.getNextPotentialPart()).isNull();
@@ -63,7 +63,7 @@ public class MessageContentExtractorTest {
     }
 
     @Test
-    public void shouldNotHandleFieldIfNoPart() throws Exception{
+    public void shouldNotHandleFieldIfNoPart() {
 
         MessageContentExtractor extractor = new MessageContentExtractor();
 
@@ -73,7 +73,7 @@ public class MessageContentExtractorTest {
     }
 
     @Test
-    public void shouldHandleField() throws Exception{
+    public void shouldHandleField() {
 
         Field fieldMock = mock(Field.class);
         when(fieldMock.getName()).thenReturn("fName");

--- a/src/test/java/com/spartasystems/holdmail/model/BuildInfoTest.java
+++ b/src/test/java/com/spartasystems/holdmail/model/BuildInfoTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class BuildInfoTest {
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(BuildInfo.class)
                       .suppress(Warning.STRICT_INHERITANCE)

--- a/src/test/java/com/spartasystems/holdmail/model/MessageAttachmentTest.java
+++ b/src/test/java/com/spartasystems/holdmail/model/MessageAttachmentTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MessageAttachmentTest {
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageAttachment.class)
                       .suppress(Warning.STRICT_INHERITANCE)
@@ -35,7 +35,7 @@ public class MessageAttachmentTest {
     }
 
     @Test
-    public void shouldHaveValidConstructor() throws Exception {
+    public void shouldHaveValidConstructor() {
 
         MessageAttachment attach = new MessageAttachment(3, "myfile", "mytype", "mydispos", 555);
         assertThat(attach.getSequence()).isEqualTo(3);

--- a/src/test/java/com/spartasystems/holdmail/model/MessageForwardCommandTest.java
+++ b/src/test/java/com/spartasystems/holdmail/model/MessageForwardCommandTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MessageForwardCommandTest {
 
     @Test
-    public void shouldSetRecipientOnConstruct() throws Exception{
+    public void shouldSetRecipientOnConstruct() {
 
         MessageForwardCommand command = new MessageForwardCommand("bob");
 
@@ -35,7 +35,7 @@ public class MessageForwardCommandTest {
     }
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageForwardCommand.class)
                       .suppress(Warning.NONFINAL_FIELDS,

--- a/src/test/java/com/spartasystems/holdmail/model/MessageListItemTest.java
+++ b/src/test/java/com/spartasystems/holdmail/model/MessageListItemTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class MessageListItemTest {
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageListItem.class)
                       .suppress(Warning.NONFINAL_FIELDS,

--- a/src/test/java/com/spartasystems/holdmail/model/MessageListTest.java
+++ b/src/test/java/com/spartasystems/holdmail/model/MessageListTest.java
@@ -35,7 +35,7 @@ public class MessageListTest {
             asList(mock(MessageListItem.class), mock(MessageListItem.class));
 
     @Test
-    public void shouldInitWithItems() throws Exception {
+    public void shouldInitWithItems() {
 
         MessageList messageList = new MessageList(TWO_ITEM_LIST);
 
@@ -44,7 +44,7 @@ public class MessageListTest {
     }
 
     @Test
-    public void shouldSetAndGetMessages() throws Exception {
+    public void shouldSetAndGetMessages() {
 
         MessageList messageList = new MessageList(TWO_ITEM_LIST);
 
@@ -56,7 +56,7 @@ public class MessageListTest {
     }
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageList.class)
                       .suppress(Warning.NONFINAL_FIELDS,

--- a/src/test/java/com/spartasystems/holdmail/model/MessageSummaryTest.java
+++ b/src/test/java/com/spartasystems/holdmail/model/MessageSummaryTest.java
@@ -49,7 +49,7 @@ public class MessageSummaryTest {
                                             mock(MessageAttachment.class), mock(MessageAttachment.class));
 
     @Test
-    public void shouldSetValuesOnConstruct() throws Exception {
+    public void shouldSetValuesOnConstruct() {
 
         MessageSummary summary = buildSummary(HTML, TEXT);
 
@@ -67,7 +67,7 @@ public class MessageSummaryTest {
     }
 
     @Test
-    public void shouldIndicateWhenMessageHasHTML() throws Exception{
+    public void shouldIndicateWhenMessageHasHTML() {
 
         assertThat(buildSummary(HTML, TEXT).getMessageHasBodyHTML()).isTrue();
         assertThat(buildSummary(null, TEXT).getMessageHasBodyHTML()).isFalse();
@@ -75,7 +75,7 @@ public class MessageSummaryTest {
     }
 
     @Test
-    public void shouldIndicateWhenMessageHasText() throws Exception{
+    public void shouldIndicateWhenMessageHasText() {
 
         assertThat(buildSummary(HTML, TEXT).getMessageHasBodyText()).isTrue();
         assertThat(buildSummary(HTML, null).getMessageHasBodyText()).isFalse();
@@ -89,7 +89,7 @@ public class MessageSummaryTest {
     }
 
     @Test
-    public void shouldHaveValidEqualsHashcode() throws Exception {
+    public void shouldHaveValidEqualsHashcode() {
 
         EqualsVerifier.forClass(MessageSummary.class)
                       .suppress(Warning.NONFINAL_FIELDS,

--- a/src/test/java/com/spartasystems/holdmail/model/MessageSummaryTest.java
+++ b/src/test/java/com/spartasystems/holdmail/model/MessageSummaryTest.java
@@ -61,7 +61,6 @@ public class MessageSummaryTest {
         assertThat(summary.getSenderHost()).isEqualTo(SENDERHOST);
         assertThat(summary.getMessageSize()).isEqualTo(SIZE);
         assertThat(summary.getRecipients()).isEqualTo(RECIPIENTS);
-        assertThat(summary.getMessageRaw()).isEqualTo(RAW);
         assertThat(summary.getMessageHeaders()).isEqualTo(HEADERS);
         assertThat(summary.getAttachments()).isEqualTo(ATTACHMENTS);
 
@@ -85,7 +84,7 @@ public class MessageSummaryTest {
 
     private MessageSummary buildSummary(String html, String text) {
         return new MessageSummary(ID, IDENTIFIER, SUBJECT, SENDER,
-                RECIEVED, SENDERHOST, SIZE, RECIPIENTS, RAW,
+                RECIEVED, SENDERHOST, SIZE, RECIPIENTS,
                 HEADERS, text, html, ATTACHMENTS);
     }
 

--- a/src/test/java/com/spartasystems/holdmail/persistence/MessageRepositoryTest.java
+++ b/src/test/java/com/spartasystems/holdmail/persistence/MessageRepositoryTest.java
@@ -51,13 +51,13 @@ public class MessageRepositoryTest extends BaseIntegrationTest{
     private MessageRepository messageRepository;
 
     @Test
-    public void shouldFindSixMessagesWithThisIsItTitle() throws Exception {
+    public void shouldFindSixMessagesWithThisIsItTitle() {
         Stream<MessageEntity> first150BySubjectDesc = messageRepository.findBySubject("This is it", new PageRequest(0,150));
         assertThat(first150BySubjectDesc.collect(Collectors.toList())).hasSize(6);
     }
 
     @Test
-    public void shouldFind25MessagesWithSomeoneExampleComSenderEmail() throws Exception {
+    public void shouldFind25MessagesWithSomeoneExampleComSenderEmail() {
         Stream<MessageEntity> first150BySenderEmail = messageRepository.findBySenderEmail("someone@example.org",new PageRequest(0,150));
 
         assertThat(first150BySenderEmail.collect(Collectors.toList())).hasSize(25);
@@ -65,7 +65,7 @@ public class MessageRepositoryTest extends BaseIntegrationTest{
     }
 
     @Test
-    public void shouldFindEmailsBySenderWithAlias() throws Exception {
+    public void shouldFindEmailsBySenderWithAlias() {
         Stream<MessageEntity> oneEmailFound = messageRepository.findBySenderEmail("someone+alias@example.org",new PageRequest(0,150));
         assertThat(oneEmailFound.collect(Collectors.toList())).hasSize(1);
     }

--- a/src/test/java/com/spartasystems/holdmail/rest/BuildInfoControllerTest.java
+++ b/src/test/java/com/spartasystems/holdmail/rest/BuildInfoControllerTest.java
@@ -44,7 +44,7 @@ public class BuildInfoControllerTest {
     private BuildInfoController buildInfoController;
 
     @Test
-    public void shouldGetBuildInfo() throws Exception {
+    public void shouldGetBuildInfo() {
 
         BuildInfo expectedInfo = mock(BuildInfo.class);
 

--- a/src/test/java/com/spartasystems/holdmail/rest/HTMLPreprocessorTest.java
+++ b/src/test/java/com/spartasystems/holdmail/rest/HTMLPreprocessorTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HTMLPreprocessorTest {
 
     @Test
-    public void shouldReplaceCIDWithRestPath() throws Exception{
+    public void shouldReplaceCIDWithRestPath() {
 
         HTMLPreprocessor preParser = new HTMLPreprocessor();
 
@@ -45,7 +45,7 @@ public class HTMLPreprocessorTest {
     }
 
     @Test
-    public void shouldPassThroughNulls() throws Exception {
+    public void shouldPassThroughNulls() {
 
         HTMLPreprocessor preParser = new HTMLPreprocessor();
 

--- a/src/test/java/com/spartasystems/holdmail/rest/MessageControllerTest.java
+++ b/src/test/java/com/spartasystems/holdmail/rest/MessageControllerTest.java
@@ -77,7 +77,7 @@ public class MessageControllerTest {
     public static final String FILE_NAME = "wibble.pdf";
 
     @Test
-    public void shouldGetMessages() throws Exception {
+    public void shouldGetMessages() {
 
         List<MessageListItem> messageMocks = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
@@ -92,7 +92,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldGetMessageContent() throws Exception {
+    public void shouldGetMessageContent() {
 
         MessageSummary summaryMock = mock(MessageSummary.class);
         doReturn(summaryMock).when(messageControllerSpy).loadMessageSummary(445);
@@ -104,7 +104,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldGetMessageContentHTML() throws Exception {
+    public void shouldGetMessageContentHTML() {
 
         MessageSummary summaryMock = setupSpyToLoadMessageSummaryMock(900, null, "original_html");
 
@@ -118,7 +118,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldGetMessageContextTEXT() throws Exception {
+    public void shouldGetMessageContextTEXT() {
 
         MessageSummary summaryMock = setupSpyToLoadMessageSummaryMock(555, "some_text", null);
 
@@ -131,7 +131,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldGetMessageContextRAW() throws Exception {
+    public void shouldGetMessageContextRAW() {
 
         String raw = "original-mime-message";
 
@@ -147,7 +147,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldGetMessageContentByPartId() throws Exception{
+    public void shouldGetMessageContentByPartId() {
 
         final int MSG_ID = 983;
         final String PART_ID = "derpPart";
@@ -173,7 +173,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldGetMessageAttachmentBySequenceId() throws Exception{
+    public void shouldGetMessageAttachmentBySequenceId() {
 
         final InputStream streamMock = mock(InputStream.class);
 
@@ -190,7 +190,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldNotSetFilenameDispositionWhenFilenameNull() throws Exception{
+    public void shouldNotSetFilenameDispositionWhenFilenameNull() {
 
         final InputStream streamMock = mock(InputStream.class);
         setupForFetchAttachment(streamMock, null);
@@ -217,7 +217,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldCallMessageServiceToForwardMail() throws Exception {
+    public void shouldCallMessageServiceToForwardMail() {
 
         final int ID = 345;
         final String RECIPIENT = "some@guy.com";
@@ -228,8 +228,7 @@ public class MessageControllerTest {
 
     }
 
-    private MessageSummary setupSpyToLoadMessageSummaryMock(int messageId, String text, String html)
-            throws Exception {
+    private MessageSummary setupSpyToLoadMessageSummaryMock(int messageId, String text, String html) {
 
         MessageSummary summaryMock = mock(MessageSummary.class);
         when(summaryMock.getMessageBodyText()).thenReturn(text);
@@ -240,7 +239,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldLoadSummary() throws Exception {
+    public void shouldLoadSummary() {
 
         Message messageMock = mock(Message.class);
         MessageSummary summaryMock = mock(MessageSummary.class);
@@ -252,7 +251,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldServeNotFoundWhenDataIsNull() throws Exception {
+    public void shouldServeNotFoundWhenDataIsNull() {
 
         ResponseEntity response = messageControllerSpy.serveContent(null, null);
 
@@ -261,7 +260,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void shouldServeContentWhenDataIsNull() throws Exception {
+    public void shouldServeContentWhenDataIsNull() {
 
         Object content = "{}";
         MediaType type = MediaType.APPLICATION_JSON;

--- a/src/test/java/com/spartasystems/holdmail/rest/MessageControllerTest.java
+++ b/src/test/java/com/spartasystems/holdmail/rest/MessageControllerTest.java
@@ -106,7 +106,7 @@ public class MessageControllerTest {
     @Test
     public void shouldGetMessageContentHTML() throws Exception {
 
-        MessageSummary summaryMock = setupSpyToLoadMessageSummaryMock(900, null, null, "original_html");
+        MessageSummary summaryMock = setupSpyToLoadMessageSummaryMock(900, null, "original_html");
 
         when(htmlPreprocessorMock.preprocess(900, summaryMock.getMessageBodyHTML())).thenReturn("modified_html");
 
@@ -120,7 +120,7 @@ public class MessageControllerTest {
     @Test
     public void shouldGetMessageContextTEXT() throws Exception {
 
-        MessageSummary summaryMock = setupSpyToLoadMessageSummaryMock(555, null, "some_text", null);
+        MessageSummary summaryMock = setupSpyToLoadMessageSummaryMock(555, "some_text", null);
 
         ResponseEntity expectedResponse = mock(ResponseEntity.class);
         String text = summaryMock.getMessageBodyText();
@@ -228,11 +228,10 @@ public class MessageControllerTest {
 
     }
 
-    private MessageSummary setupSpyToLoadMessageSummaryMock(int messageId, String raw, String text, String html)
+    private MessageSummary setupSpyToLoadMessageSummaryMock(int messageId, String text, String html)
             throws Exception {
 
         MessageSummary summaryMock = mock(MessageSummary.class);
-        when(summaryMock.getMessageRaw()).thenReturn(raw);
         when(summaryMock.getMessageBodyText()).thenReturn(text);
         when(summaryMock.getMessageBodyHTML()).thenReturn(html);
         doReturn(summaryMock).when(messageControllerSpy).loadMessageSummary(messageId);

--- a/src/test/java/com/spartasystems/holdmail/service/MessageServiceTest.java
+++ b/src/test/java/com/spartasystems/holdmail/service/MessageServiceTest.java
@@ -65,7 +65,7 @@ public class MessageServiceTest {
     private MessageService messageService;
 
     @Test
-    public void shouldSaveMessage() throws Exception {
+    public void shouldSaveMessage() {
 
         Message messageToSave = mock(Message.class);
         Message savedMessage = mock(Message.class);
@@ -81,7 +81,7 @@ public class MessageServiceTest {
     }
 
     @Test
-    public void shouldGetMessage() throws Exception {
+    public void shouldGetMessage() {
 
         long messageId = 34234;
 
@@ -96,7 +96,7 @@ public class MessageServiceTest {
     }
 
     @Test
-    public void shouldFindMessagesAndReturnAllIfEmailIsBlank() throws Exception {
+    public void shouldFindMessagesAndReturnAllIfEmailIsBlank() {
 
         List<MessageEntity> entities = asList(mock(MessageEntity.class), mock(MessageEntity.class));
         MessageList messageListMock = mock(MessageList.class);
@@ -109,7 +109,7 @@ public class MessageServiceTest {
     }
 
     @Test
-    public void shouldFindMessagesForRecipientIfEmailIsNotBlank() throws Exception {
+    public void shouldFindMessagesForRecipientIfEmailIsNotBlank() {
 
         List<MessageEntity> entities = asList(mock(MessageEntity.class), mock(MessageEntity.class));
         MessageList messageListMock = mock(MessageList.class);
@@ -122,7 +122,7 @@ public class MessageServiceTest {
     }
 
     @Test
-    public void shouldForwardMail() throws Exception {
+    public void shouldForwardMail() {
 
         Message messageMock = mock(Message.class);
         when(messageMock.getRawMessage()).thenReturn("RAW message");

--- a/src/test/java/com/spartasystems/holdmail/smtp/OutgoingMailSenderTest.java
+++ b/src/test/java/com/spartasystems/holdmail/smtp/OutgoingMailSenderTest.java
@@ -64,7 +64,7 @@ public class OutgoingMailSenderTest {
     private OutgoingMailSender mailSenderSpy = new OutgoingMailSender();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         suppress(methodsDeclaredIn(Transport.class));
     }
 
@@ -122,7 +122,7 @@ public class OutgoingMailSenderTest {
     }
 
     @Test
-    public void shouldGetMailSession() throws Exception {
+    public void shouldGetMailSession() {
 
         doReturn(OUTGOING_SERVER).when(mailSenderSpy).getOutgoingServer();
         doReturn(OUTGOING_PORT).when(mailSenderSpy).getOutgoingPort();
@@ -138,7 +138,7 @@ public class OutgoingMailSenderTest {
     }
 
     @Test
-    public void shouldGetInjectedProps() throws Exception {
+    public void shouldGetInjectedProps() {
 
         Whitebox.setInternalState(mailSenderSpy, "outgoingServer", "outserver");
         Whitebox.setInternalState(mailSenderSpy, "outgoingPort", 999);


### PR DESCRIPTION
Issue #14 -  Since the next release is a major version release, I'm dropping the 'messageRaw' attribute altogether instead of making it enabled with an optional properties flag.   Delivering this attribute causes significant impact when attachments are present. 

REST clients that wish to fetch the original message content can make an additional call to /rest/messages/{ID}/raw. 

Also - there were a lot of redundant 'throws' clauses throughout the codebase, these are removed too.