### PR TITLE
Issue #14 - list shows whether mail has attachments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,34 +198,34 @@ buildRpm {
     link('/etc/init.d/holdmail', RPM_INSTALL_DIR + '/bin/holdmail.jar')
 }
 
-//task runNpmInstall(type: NpmTask) {
-//  workingDir = file("${project.projectDir}/client")
-//
-//  args = ['install']
-//}
+task runNpmInstall(type: NpmTask) {
+  workingDir = file("${project.projectDir}/client")
 
-//task compileUI(type: NpmTask) {
-//  dependsOn 'runNpmInstall'
-//
-//  workingDir = file("${project.projectDir}/client")
-//
-//  args = ['run', 'build']
-//}
-//
-//task testUI(type: NpmTask) {
-//  dependsOn 'runNpmInstall'
-//
-//  workingDir = file("${project.projectDir}/client")
-//
-//  args = ['run', 'test']
-//}
-//
-//task buildUI(type: Copy) {
-//  dependsOn 'compileUI'
-//
-//  from "${project.projectDir}/client/dist"
-//  into "${project.projectDir}/src/main/resources/static"
-//}
+  args = ['install']
+}
+
+task compileUI(type: NpmTask) {
+  dependsOn 'runNpmInstall'
+
+  workingDir = file("${project.projectDir}/client")
+
+  args = ['run', 'build']
+}
+
+task testUI(type: NpmTask) {
+  dependsOn 'runNpmInstall'
+
+  workingDir = file("${project.projectDir}/client")
+
+  args = ['run', 'test']
+}
+
+task buildUI(type: Copy) {
+  dependsOn 'compileUI'
+
+  from "${project.projectDir}/client/dist"
+  into "${project.projectDir}/src/main/resources/static"
+}
 
 test {
     testLogging {
@@ -234,8 +234,8 @@ test {
     }
 }
 
-//test.dependsOn testUI
-//compileJava.dependsOn('buildUI')
+test.dependsOn testUI
+compileJava.dependsOn('buildUI')
 tasks.build.dependsOn('buildRpm')
 
 task srcJAR(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -198,34 +198,34 @@ buildRpm {
     link('/etc/init.d/holdmail', RPM_INSTALL_DIR + '/bin/holdmail.jar')
 }
 
-task runNpmInstall(type: NpmTask) {
-  workingDir = file("${project.projectDir}/client")
+//task runNpmInstall(type: NpmTask) {
+//  workingDir = file("${project.projectDir}/client")
+//
+//  args = ['install']
+//}
 
-  args = ['install']
-}
-
-task compileUI(type: NpmTask) {
-  dependsOn 'runNpmInstall'
-
-  workingDir = file("${project.projectDir}/client")
-
-  args = ['run', 'build']
-}
-
-task testUI(type: NpmTask) {
-  dependsOn 'runNpmInstall'
-
-  workingDir = file("${project.projectDir}/client")
-
-  args = ['run', 'test']
-}
-
-task buildUI(type: Copy) {
-  dependsOn 'compileUI'
-
-  from "${project.projectDir}/client/dist"
-  into "${project.projectDir}/src/main/resources/static"
-}
+//task compileUI(type: NpmTask) {
+//  dependsOn 'runNpmInstall'
+//
+//  workingDir = file("${project.projectDir}/client")
+//
+//  args = ['run', 'build']
+//}
+//
+//task testUI(type: NpmTask) {
+//  dependsOn 'runNpmInstall'
+//
+//  workingDir = file("${project.projectDir}/client")
+//
+//  args = ['run', 'test']
+//}
+//
+//task buildUI(type: Copy) {
+//  dependsOn 'compileUI'
+//
+//  from "${project.projectDir}/client/dist"
+//  into "${project.projectDir}/src/main/resources/static"
+//}
 
 test {
     testLogging {
@@ -234,8 +234,8 @@ test {
     }
 }
 
-test.dependsOn testUI
-compileJava.dependsOn('buildUI')
+//test.dependsOn testUI
+//compileJava.dependsOn('buildUI')
 tasks.build.dependsOn('buildRpm')
 
 task srcJAR(type: Jar) {

--- a/src/main/java/com/spartasystems/holdmail/domain/MessageContent.java
+++ b/src/main/java/com/spartasystems/holdmail/domain/MessageContent.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.h2.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,9 +59,9 @@ public class MessageContent {
                     .orElse(null);
     }
 
-    public List<MessageContentPart> findAttachmentParts() {
+    public List<MessageContentPart> findAttachmentParts(boolean includeInline) {
         return parts.stream()
-                    .filter(MessageContentPart::isAttachment)
+                    .filter(part -> part.hasAttachmentDisposition(includeInline))
                     .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/spartasystems/holdmail/domain/MessageContentPart.java
+++ b/src/main/java/com/spartasystems/holdmail/domain/MessageContentPart.java
@@ -20,9 +20,7 @@ package com.spartasystems.holdmail.domain;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -34,10 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Predicate;
 
 public class MessageContentPart {
 
@@ -82,14 +77,21 @@ public class MessageContentPart {
         return type != null && type.equals("text/plain");
     }
 
-    public boolean isAttachment() {
+    /**
+     * Whether this content part's disposition indicates this is an attachment part
+     * @param includeInline An attachment is a part with a 'disposition' value of 'inline' or 'attachment'. If
+     *                      this parameter is false, those with 'inline' disposition will result in false.
+     * @return Whether this part's disposition represents an attachment.
+     */
+    public boolean hasAttachmentDisposition(boolean includeInline) {
         HeaderValue disposition = headers.get(FieldName.CONTENT_DISPOSITION);
-        return disposition != null && (disposition.hasValue("inline") || disposition.hasValue("attachment"));
+        return disposition != null
+                && ((includeInline && disposition.hasValue("inline")) || disposition.hasValue("attachment"));
     }
 
     public String getAttachmentFilename() {
 
-        if (!isAttachment()) {
+        if (!hasAttachmentDisposition(true)) {
             return null;
         }
 

--- a/src/main/java/com/spartasystems/holdmail/mapper/MessageListMapper.java
+++ b/src/main/java/com/spartasystems/holdmail/mapper/MessageListMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,8 @@ public class MessageListMapper {
                 entity.getReceivedDate().getTime(),
                 entity.getSenderEmail(),
                 recipientString,
-                entity.getSubject());
+                entity.getSubject(),
+                entity.getHasAttachments());
     }
 
 

--- a/src/main/java/com/spartasystems/holdmail/mapper/MessageMapper.java
+++ b/src/main/java/com/spartasystems/holdmail/mapper/MessageMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ public class MessageMapper {
                                     .stream()
                                     .map(MessageRecipientEntity::new)
                                     .collect(Collectors.toSet()));
+
+        entity.setHasAttachments(!message.getContent().findAttachmentParts(false).isEmpty());
         return entity;
 
     }

--- a/src/main/java/com/spartasystems/holdmail/mapper/MessageSummaryMapper.java
+++ b/src/main/java/com/spartasystems/holdmail/mapper/MessageSummaryMapper.java
@@ -44,7 +44,7 @@ public class MessageSummaryMapper {
 
         MessageContent messageContent = message.getContent();
 
-        List<MessageAttachment> attachments = messageContent.findAttachmentParts()
+        List<MessageAttachment> attachments = messageContent.findAttachmentParts(true)
                                                             .stream()
                                                             .map(attachmentMapper::fromMessageContentPart)
                                                             .collect(toList());

--- a/src/main/java/com/spartasystems/holdmail/model/MessageListItem.java
+++ b/src/main/java/com/spartasystems/holdmail/model/MessageListItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,13 +30,15 @@ public class MessageListItem {
     private String senderEmail;
     private String recipients;
     private String subject;
+    private boolean hasAttachments;
 
-    public MessageListItem(long messageId, long receivedDate, String senderEmail, String recipients, String subject) {
+    public MessageListItem(long messageId, long receivedDate, String senderEmail, String recipients, String subject, boolean hasAttachments) {
         this.messageId = messageId;
         this.receivedDate = receivedDate;
         this.senderEmail = senderEmail;
         this.recipients = recipients;
         this.subject = subject;
+        this.hasAttachments = hasAttachments;
     }
 
     public long getMessageId() {
@@ -57,6 +59,10 @@ public class MessageListItem {
 
     public String getSubject() {
         return subject;
+    }
+
+    public boolean getHasAttachments() {
+        return hasAttachments;
     }
 
     @Override

--- a/src/main/java/com/spartasystems/holdmail/persistence/MessageEntity.java
+++ b/src/main/java/com/spartasystems/holdmail/persistence/MessageEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 - 2017 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,9 @@ public class MessageEntity {
     @Column(name = "sender_host")
     private String senderHost;
 
+    @Column(name = "has_attachments")
+    private boolean hasAttachments;
+
     @NotNull
     @Column(name = "message_size")
     private int messageSize;
@@ -132,6 +135,14 @@ public class MessageEntity {
 
     public void setReceivedDate(Date receivedDate) {
         this.receivedDate = receivedDate;
+    }
+
+    public boolean getHasAttachments() {
+        return hasAttachments;
+    }
+
+    public void setHasAttachments(boolean hasAttachments) {
+        this.hasAttachments = hasAttachments;
     }
 
     public int getMessageSize() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016 Sparta Systems, Inc
+# Copyright 2016 - 2018 Sparta Systems, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,4 +46,7 @@ security.basic.enabled=false
 #security.user.name=user
 #security.user.password=pass
 
-
+# INFO level on these three package is incredibly spammy by default
+logging.level.org.springframework=WARN
+logging.level.org.hibernate=WARN
+logging.level.org.apache.catalina=WARN

--- a/src/main/resources/db/migration/V1.1_003__add_has_attachments_flag.sql
+++ b/src/main/resources/db/migration/V1.1_003__add_has_attachments_flag.sql
@@ -1,0 +1,3 @@
+
+alter table message add column has_attachments tinyint(1) not null default 0;
+

--- a/src/test/java/com/spartasystems/holdmail/EntityPersistenceTest.java
+++ b/src/test/java/com/spartasystems/holdmail/EntityPersistenceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 - 2017 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ public class EntityPersistenceTest extends BaseIntegrationTest {
         assertThat(loaded.getSenderEmail()).isEqualTo(SENDER_EMAIL);
         assertThat(loaded.getSenderHost()).isEqualTo(SENDER_HOST);
         assertThat(loaded.getSubject()).isEqualTo(SUBJECT);
+        assertThat(loaded.getHasAttachments()).isEqualTo(true);
 
     }
 
@@ -165,6 +166,7 @@ public class EntityPersistenceTest extends BaseIntegrationTest {
         entity.setSenderEmail(SENDER_EMAIL);
         entity.setSenderHost(SENDER_HOST);
         entity.setSubject(SUBJECT);
+        entity.setHasAttachments(true);
         return entity;
     }
 }

--- a/src/test/java/com/spartasystems/holdmail/domain/MessageContentPartTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/MessageContentPartTest.java
@@ -162,21 +162,23 @@ public class MessageContentPartTest {
     }
 
     @Test
-    public void shouldReturnIsAttachmentTrueWhenDispositionIsInline() {
+    public void shouldReturnIsAttachmentWhenDispositionIsInline() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         messageContentPart.setHeader(CONTENT_DISPOSITION, "inline");
 
-        assertThat(messageContentPart.isAttachment()).isTrue();
+        assertThat(messageContentPart.hasAttachmentDisposition(true)).isTrue();
+        assertThat(messageContentPart.hasAttachmentDisposition(false)).isFalse();
     }
 
     @Test
-    public void shouldReturnIsAttachmentTrueWhenDispositionIsAttachment() {
+    public void shouldReturnIsAttachmentWhenDispositionIsAttachment() {
 
         MessageContentPart messageContentPart = new MessageContentPart();
         messageContentPart.setHeader(CONTENT_DISPOSITION, "attachment");
 
-        assertThat(messageContentPart.isAttachment()).isTrue();
+        assertThat(messageContentPart.hasAttachmentDisposition(true)).isTrue();
+        assertThat(messageContentPart.hasAttachmentDisposition(false)).isTrue();
     }
 
     @Test
@@ -185,23 +187,23 @@ public class MessageContentPartTest {
         // not set at all
         MessageContentPart messageContentPart = new MessageContentPart();
         messageContentPart.getHeaders().remove(CONTENT_DISPOSITION);
-        assertThat(messageContentPart.isAttachment()).isFalse();
+        assertThat(messageContentPart.hasAttachmentDisposition(true)).isFalse();
 
         // blank
         messageContentPart.setHeader(CONTENT_DISPOSITION, "");
-        assertThat(messageContentPart.isAttachment()).isFalse();
+        assertThat(messageContentPart.hasAttachmentDisposition(true)).isFalse();
 
         // garbage
         messageContentPart.setHeader(CONTENT_DISPOSITION, "poop");
-        assertThat(messageContentPart.isAttachment()).isFalse();
+        assertThat(messageContentPart.hasAttachmentDisposition(true)).isFalse();
 
         // case sensitive?
         messageContentPart.setHeader(CONTENT_DISPOSITION, "iNlINe");
-        assertThat(messageContentPart.isAttachment()).isFalse();
+        assertThat(messageContentPart.hasAttachmentDisposition(true)).isFalse();
 
         // valid, but doesn't start with
         messageContentPart.setHeader(CONTENT_DISPOSITION, "blah inline");
-        assertThat(messageContentPart.isAttachment()).isFalse();
+        assertThat(messageContentPart.hasAttachmentDisposition(true)).isFalse();
 
     }
 
@@ -209,7 +211,7 @@ public class MessageContentPartTest {
     public void shouldReturnNullAttachmentFilenameIfNotAttachment() {
 
         MessageContentPart partSpy = spy(new MessageContentPart());
-        doReturn(false).when(partSpy).isAttachment();
+        doReturn(false).when(partSpy).hasAttachmentDisposition(true);
 
         assertThat(partSpy.getAttachmentFilename()).isNull();
     }

--- a/src/test/java/com/spartasystems/holdmail/domain/MessageContentTest.java
+++ b/src/test/java/com/spartasystems/holdmail/domain/MessageContentTest.java
@@ -116,16 +116,30 @@ public class MessageContentTest {
     }
 
     @Test
-    public void shouldFindAllAttachments() {
+    public void shouldFindAllAttachmentsWithDispositionTrue() {
 
-        when(part1Mock.isAttachment()).thenReturn(false);
-        when(part2Mock.isAttachment()).thenReturn(true);
-        when(part3Mock.isAttachment()).thenReturn(false);
-        when(part4Mock.isAttachment()).thenReturn(true);
+        when(part1Mock.hasAttachmentDisposition(true)).thenReturn(false);
+        when(part2Mock.hasAttachmentDisposition(true)).thenReturn(true);
+        when(part3Mock.hasAttachmentDisposition(true)).thenReturn(false);
+        when(part4Mock.hasAttachmentDisposition(true)).thenReturn(true);
 
         MessageContent messageContent = buildMimeBodyPartsWith4Parts();
 
-        assertThat(messageContent.findAttachmentParts()).containsExactly(part2Mock, part4Mock);
+        assertThat(messageContent.findAttachmentParts(true)).containsExactly(part2Mock, part4Mock);
+
+    }
+
+    @Test
+    public void shouldFindAllAttachmentsWithDispositionFalse() {
+
+        when(part1Mock.hasAttachmentDisposition(false)).thenReturn(false);
+        when(part2Mock.hasAttachmentDisposition(false)).thenReturn(false);
+        when(part3Mock.hasAttachmentDisposition(false)).thenReturn(true);
+        when(part4Mock.hasAttachmentDisposition(false)).thenReturn(true);
+
+        MessageContent messageContent = buildMimeBodyPartsWith4Parts();
+
+        assertThat(messageContent.findAttachmentParts(false)).containsExactly(part3Mock, part4Mock);
 
     }
 

--- a/src/test/java/com/spartasystems/holdmail/mapper/MessageListMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/MessageListMapperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ public class MessageListMapperTest {
         entity.setReceivedDate(receivedDate);
         entity.setSenderEmail(EMAIL_CARL);
         entity.setSubject(MESSAGE_SUBJECT);
+        entity.setHasAttachments(false);
 
         MessageListItem messageListItem = messageListMapperSpy.toMessageListItem(entity);
         assertThat(messageListItem.getMessageId()).isEqualTo(MESSAGE_ID);
@@ -108,7 +109,12 @@ public class MessageListMapperTest {
         assertThat(messageListItem.getSenderEmail()).isEqualTo(EMAIL_CARL);
         assertThat(messageListItem.getRecipients()).isEqualTo(EMAIL_HOMER + ", " + EMAIL_MONTY);
         assertThat(messageListItem.getSubject()).isEqualTo(MESSAGE_SUBJECT);
+        assertThat(messageListItem.getHasAttachments()).isFalse();
 
+        // repeat, but with the attachment as true
+        entity.setHasAttachments(true);
+        assertThat(messageListMapperSpy.toMessageListItem(entity).getHasAttachments()).isTrue();
     }
+
 
 }

--- a/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
+++ b/src/test/java/com/spartasystems/holdmail/mapper/MessageSummaryMapperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 - 2017 Sparta Systems, Inc
+ * Copyright 2016 - 2018 Sparta Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ public class MessageSummaryMapperTest {
         MessageAttachment attachmentMock1 = mock(MessageAttachment.class);
         MessageAttachment attachmentMock2 = mock(MessageAttachment.class);
 
-        when(messageContentMock.findAttachmentParts()).thenReturn(asList(attContentMock1, attContentMock2));
+        when(messageContentMock.findAttachmentParts(true)).thenReturn(asList(attContentMock1, attContentMock2));
         when(attachmentMapperMock.fromMessageContentPart(attContentMock1)).thenReturn(attachmentMock1);
         when(attachmentMapperMock.fromMessageContentPart(attContentMock2)).thenReturn(attachmentMock2);
 

--- a/src/test/resources/jsonschema/message-list.json
+++ b/src/test/resources/jsonschema/message-list.json
@@ -21,6 +21,9 @@
           },
           "subject": {
             "type": "string"
+          },
+          "hasAttachments": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -28,7 +31,8 @@
           "receivedDate",
           "senderEmail",
           "recipients",
-          "subject"
+          "subject",
+          "hasAttachments"
         ]
       }
     }


### PR DESCRIPTION
Issue #14 - Add 'hasAttachments' flag to /rest/messages model.  Decided against patching existing data, as the simplest patch:

`update message set has_attachments=1 where message_body like '%Content-Disposition: attachment%';`

could be too expensive for those with gigs of attachments.  (I.e. that chap that complains about performance of his large DB).

Also: :football: :football: GO EAGLES :football: :football: